### PR TITLE
fix: support change children via setState

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,14 +18,30 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyPage extends StatelessWidget {
+class MyPage extends StatefulWidget {
   const MyPage({Key? key}) : super(key: key);
+
+  @override
+  State<MyPage> createState() => _MyPageState();
+}
+
+class _MyPageState extends State<MyPage> {
+  bool _showFirst = true;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Resizable Widget Example'),
+        actions: [
+          IconButton(
+              onPressed: () {
+                setState(() {
+                  _showFirst = !_showFirst;
+                });
+              },
+              icon: const Icon(Icons.settings)),
+        ],
       ),
       body: ResizableWidget(
         isHorizontalSeparator: false,
@@ -34,7 +50,7 @@ class MyPage extends StatelessWidget {
         separatorSize: 4,
         onResized: _printResizeInfo,
         children: [
-          Container(color: Colors.greenAccent),
+          if(_showFirst) Container(color: Colors.greenAccent),
           ResizableWidget(
             isHorizontalSeparator: true,
             separatorColor: Colors.blue,
@@ -47,7 +63,7 @@ class MyPage extends StatelessWidget {
                   Container(color: Colors.yellowAccent),
                   Container(color: Colors.redAccent),
                 ],
-                percentages: const [0.2, 0.5, 0.3],
+                percentages: const [0.2, 0.5, 0.3]
               ),
               Container(color: Colors.redAccent),
             ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,13 +34,13 @@ class _MyPageState extends State<MyPage> {
       appBar: AppBar(
         title: const Text('Resizable Widget Example'),
         actions: [
-          IconButton(
+          TextButton(
               onPressed: () {
                 setState(() {
                   _showFirst = !_showFirst;
                 });
               },
-              icon: const Icon(Icons.settings)),
+              child: const Text('Change chidren')),
         ],
       ),
       body: ResizableWidget(

--- a/lib/src/resizable_widget.dart
+++ b/lib/src/resizable_widget.dart
@@ -72,15 +72,23 @@ class ResizableWidget extends StatefulWidget {
 }
 
 class _ResizableWidgetState extends State<ResizableWidget> {
-  late ResizableWidgetArgsInfo _info;
   late ResizableWidgetController _controller;
 
   @override
   void initState() {
     super.initState();
-
-    _info = ResizableWidgetArgsInfo(widget);
     _controller = ResizableWidgetController(_info);
+  }  
+  
+  ResizableWidgetArgsInfo get _info => ResizableWidgetArgsInfo(widget) ;
+
+  @override
+  void didUpdateWidget(covariant ResizableWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.children != widget.children) {
+      _controller = ResizableWidgetController(_info);
+      _controller.update();
+    }
   }
 
   @override

--- a/lib/src/resizable_widget_controller.dart
+++ b/lib/src/resizable_widget_controller.dart
@@ -28,6 +28,10 @@ class ResizableWidgetController {
     _model.callOnResized();
   }
 
+  void update() {
+    eventStream.add(this);
+  }
+
   void tryHideOrShow(int separatorIndex) {
     final result = _model.tryHideOrShow(separatorIndex);
 


### PR DESCRIPTION
The pr could fix #9 .
Now you can update children via setState out of the resizable widget. I also update the example to show the fix. I am not sure if this is the best solution.
Pleae have a check!
Thanks!