### PR TITLE
Apply Min/Max Constraints

### DIFF
--- a/lib/src/resizable_widget.dart
+++ b/lib/src/resizable_widget.dart
@@ -24,10 +24,10 @@ class ResizableWidget extends StatefulWidget {
   final List<double>? percentages;
 
   /// Applies a Maximum Percent of the screen each widget can occupy
-  /// One element must be set to null
+  /// At least one element must be set to double.infinity
   final List<double?>? maxPercentages;
   /// Applies a Minimum Percent of the screen each widget can occupy
-  /// One element must be set to null
+  /// At least one element must be set to 0.0
   final List<double?>? minPercentages;
 
   /// When set to true, creates horizontal separators.
@@ -74,8 +74,8 @@ class ResizableWidget extends StatefulWidget {
     assert(percentages == null || percentages!.length == children.length);
     assert(percentages == null ||
         percentages!.reduce((value, element) => value + element) == 1);
-    assert(maxPercentages == null || maxPercentages!.contains(null));
-    assert(minPercentages == null || minPercentages!.contains(null));
+    assert(maxPercentages == null || maxPercentages!.contains(double.infinity));
+    assert(minPercentages == null || minPercentages!.contains(0));
   }
 
   @override

--- a/lib/src/resizable_widget.dart
+++ b/lib/src/resizable_widget.dart
@@ -75,7 +75,7 @@ class ResizableWidget extends StatefulWidget {
     assert(percentages == null ||
         percentages!.reduce((value, element) => value + element) == 1);
     assert(maxPercentages == null || maxPercentages!.contains(double.infinity));
-    assert(minPercentages == null || minPercentages!.contains(0));
+    assert(minPercentages == null || minPercentages!.reduce((value, element) => value! + element!)! < 1);
   }
 
   @override

--- a/lib/src/resizable_widget.dart
+++ b/lib/src/resizable_widget.dart
@@ -23,6 +23,13 @@ class ResizableWidget extends StatefulWidget {
   /// If this value is [null], [children] will be split into the same size.
   final List<double>? percentages;
 
+  /// Applies a Maximum Percent of the screen each widget can occupy
+  /// One element must be set to null
+  final List<double?>? maxPercentages;
+  /// Applies a Minimum Percent of the screen each widget can occupy
+  /// One element must be set to null
+  final List<double?>? minPercentages;
+
   /// When set to true, creates horizontal separators.
   @Deprecated('Use [isHorizontalSeparator] instead')
   final bool isColumnChildren;
@@ -53,6 +60,8 @@ class ResizableWidget extends StatefulWidget {
     Key? key,
     required this.children,
     this.percentages,
+    this.maxPercentages,
+    this.minPercentages,
     @Deprecated('Use [isHorizontalSeparator] instead')
         this.isColumnChildren = false,
     this.isHorizontalSeparator = false,
@@ -65,6 +74,8 @@ class ResizableWidget extends StatefulWidget {
     assert(percentages == null || percentages!.length == children.length);
     assert(percentages == null ||
         percentages!.reduce((value, element) => value + element) == 1);
+    assert(maxPercentages == null || maxPercentages!.contains(null));
+    assert(minPercentages == null || minPercentages!.contains(null));
   }
 
   @override

--- a/lib/src/resizable_widget_args_info.dart
+++ b/lib/src/resizable_widget_args_info.dart
@@ -4,6 +4,8 @@ import 'resizable_widget.dart';
 class ResizableWidgetArgsInfo {
   final List<Widget> children;
   final List<double>? percentages;
+  final List<double?>? maxPercentages;
+  final List<double?>? minPercentages;
   final bool isHorizontalSeparator;
   final bool isDisabledSmartHide;
   final double separatorSize;
@@ -13,6 +15,8 @@ class ResizableWidgetArgsInfo {
   ResizableWidgetArgsInfo(ResizableWidget widget)
       : children = widget.children,
         percentages = widget.percentages,
+        maxPercentages = widget.maxPercentages,
+        minPercentages = widget.minPercentages,
         isHorizontalSeparator =
             // TODO: delete the deprecated member on the next minor update.
             // ignore: deprecated_member_use_from_same_package

--- a/lib/src/resizable_widget_child_data.dart
+++ b/lib/src/resizable_widget_child_data.dart
@@ -6,5 +6,7 @@ class ResizableWidgetChildData {
   double? percentage;
   double? defaultPercentage;
   double? hidingPercentage;
-  ResizableWidgetChildData(this.widget, this.percentage);
+  double? maxPercentage;
+  double? minPercentage;
+  ResizableWidgetChildData(this.widget, this.percentage, this.maxPercentage, this.minPercentage);
 }


### PR DESCRIPTION
Addresses Request for applying Min/Max constraints to each Widget (https://github.com/ibako/resizable_widget/issues/11)
Implementation requires providing a separate `List<double?>` array for the respective Min / Max behavior. These lists requires at least 1 element to be `0.0` / `double.infinity` (declaring a min / max value for _each_ element would defeat the purpose of this package)

Sample Declaration:

```
return Scaffold(
      body: ResizableWidget(
        children: [
          itemA(context), itemB(context), itemC(context)
        ],
        isHorizontalSeparator: true,
        minPercentages: const [
          0.25, 0.0, 0.1
        ],
        maxPercentages: const [
          0.5, double.infinity, double.infinity
        ],
      ),
    );
  }
```