### PR TITLE
Add Child Constraints Support to ResizableWidget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,6 +11,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'Resizable Widget Example',
       theme: ThemeData.dark(),
       home: const MyPage(),
@@ -18,42 +19,62 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyPage extends StatelessWidget {
+
+class MyPage extends StatefulWidget {
   const MyPage({Key? key}) : super(key: key);
 
   @override
+  State<MyPage> createState() => _MyPageState();
+}
+
+class _MyPageState extends State<MyPage> {
+  var textDirection = TextDirection.rtl;
+
+  @override
   Widget build(BuildContext context) {
+    final rtl = textDirection == TextDirection.rtl;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Resizable Widget Example'),
-      ),
-      body: ResizableWidget(
-        isHorizontalSeparator: false,
-        isDisabledSmartHide: false,
-        separatorColor: Colors.white12,
-        separatorSize: 4,
-        onResized: _printResizeInfo,
-        children: [
-          Container(color: Colors.greenAccent),
-          ResizableWidget(
-            isHorizontalSeparator: true,
-            separatorColor: Colors.blue,
-            separatorSize: 10,
-            children: [
-              Container(color: Colors.greenAccent),
-              ResizableWidget(
-                children: [
-                  Container(color: Colors.greenAccent),
-                  Container(color: Colors.yellowAccent),
-                  Container(color: Colors.redAccent),
-                ],
-                percentages: const [0.2, 0.5, 0.3],
-              ),
-              Container(color: Colors.redAccent),
-            ],
+        title: Text('Resizable Widget Example (${rtl? 'Right-to-Left' : 'Left-to-Right'})'),
+        actions: [
+          IconButton(
+            icon: Icon(rtl ? Icons.subdirectory_arrow_left : Icons.subdirectory_arrow_right),
+            onPressed: () {
+              setState(() => textDirection = rtl? TextDirection.ltr : TextDirection.rtl);
+            },
           ),
-          Container(color: Colors.redAccent),
         ],
+      ),
+      body: Directionality(
+        textDirection: textDirection,
+        child: ResizableWidget(
+          isHorizontalSeparator: false,
+          isDisabledSmartHide: false,
+          separatorColor: Colors.white12,
+          separatorSize: 4,
+          onResized: _printResizeInfo,
+          children: [
+            Container(color: Colors.greenAccent),
+            ResizableWidget(
+              isHorizontalSeparator: true,
+              separatorColor: Colors.blue,
+              separatorSize: 10,
+              children: [
+                Container(color: Colors.greenAccent),
+                ResizableWidget(
+                  children: [
+                    Container(color: Colors.greenAccent),
+                    Container(color: Colors.yellowAccent),
+                    Container(color: Colors.redAccent),
+                  ],
+                  percentages: const [0.2, 0.5, 0.3],
+                ),
+                Container(color: Colors.redAccent),
+              ],
+            ),
+            Container(color: Colors.redAccent),
+          ],
+        ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,6 +81,11 @@ class _MyPageState extends State<MyPage> {
                   ),
                 ),
                 ResizableWidget(
+                  constraints: const [
+                    null,
+                    BoxConstraints(minHeight: 150, maxHeight: 200),
+                    null,
+                  ],
                   children: [
                     Container(color: Colors.greenAccent),
                     Container(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,7 +19,6 @@ class MyApp extends StatelessWidget {
   }
 }
 
-
 class MyPage extends StatefulWidget {
   const MyPage({Key? key}) : super(key: key);
 
@@ -35,12 +34,12 @@ class _MyPageState extends State<MyPage> {
     final rtl = textDirection == TextDirection.rtl;
     return Scaffold(
       appBar: AppBar(
-        title: Text('Resizable Widget Example (${rtl? 'Right-to-Left' : 'Left-to-Right'})'),
+        title: Text('Resizable Widget Example (${rtl ? 'Right-to-Left' : 'Left-to-Right'})'),
         actions: [
           IconButton(
             icon: Icon(rtl ? Icons.subdirectory_arrow_left : Icons.subdirectory_arrow_right),
             onPressed: () {
-              setState(() => textDirection = rtl? TextDirection.ltr : TextDirection.rtl);
+              setState(() => textDirection = rtl ? TextDirection.ltr : TextDirection.rtl);
             },
           ),
         ],
@@ -53,18 +52,43 @@ class _MyPageState extends State<MyPage> {
           separatorColor: Colors.white12,
           separatorSize: 4,
           onResized: _printResizeInfo,
+          constraints: const [
+            BoxConstraints(minWidth: 100),
+            null,
+            null,
+          ],
           children: [
-            Container(color: Colors.greenAccent),
+            Container(
+              color: Colors.green,
+              child: const Center(
+                child: Text('Min Width is 100', style: TextStyle(color: Colors.black)),
+              ),
+            ),
             ResizableWidget(
               isHorizontalSeparator: true,
               separatorColor: Colors.blue,
               separatorSize: 10,
+              constraints: const [
+                BoxConstraints(minHeight: 200),
+                BoxConstraints(minHeight: 100, maxHeight: 250),
+                null,
+              ],
               children: [
-                Container(color: Colors.greenAccent),
+                Container(
+                  color: Colors.amber,
+                  child: const Center(
+                    child: Text('Min Height is 200', style: TextStyle(color: Colors.black)),
+                  ),
+                ),
                 ResizableWidget(
                   children: [
                     Container(color: Colors.greenAccent),
-                    Container(color: Colors.yellowAccent),
+                    Container(
+                      color: Colors.yellowAccent,
+                      child: const Center(
+                        child: Text('Min Height is 100\nMax Height is 250', style: TextStyle(color: Colors.black)),
+                      ),
+                    ),
                     Container(color: Colors.redAccent),
                   ],
                   percentages: const [0.2, 0.5, 0.3],
@@ -81,6 +105,6 @@ class _MyPageState extends State<MyPage> {
 
   void _printResizeInfo(List<WidgetSizeInfo> dataList) {
     // ignore: avoid_print
-    print(dataList.map((x) => '(${x.size}, ${x.percentage}%)').join(", "));
+    // print(dataList.map((x) => '(${x.size}, ${x.percentage}%)').join(", "));
   }
 }

--- a/lib/src/resizable_widget.dart
+++ b/lib/src/resizable_widget.dart
@@ -114,10 +114,13 @@ class _ResizableWidgetState extends State<ResizableWidget> {
       return child.widget;
     }
 
-    return SizedBox(
-      width: _info.isHorizontalSeparator ? double.infinity : child.size,
-      height: _info.isHorizontalSeparator ? child.size : double.infinity,
-      child: child.widget,
+    return ConstrainedBox(
+      constraints: child.constraints ?? const BoxConstraints(),
+      child: SizedBox(
+        width: _info.isHorizontalSeparator ? double.infinity : child.size,
+        height: _info.isHorizontalSeparator ? child.size : double.infinity,
+        child: child.widget,
+      ),
     );
   }
 }

--- a/lib/src/resizable_widget.dart
+++ b/lib/src/resizable_widget.dart
@@ -23,6 +23,19 @@ class ResizableWidget extends StatefulWidget {
   /// If this value is [null], [children] will be split into the same size.
   final List<double>? percentages;
 
+  /// Constraints among the [ResizableWidget] children.
+  ///
+  /// Used to force the widget to doesn't break constraints sizes.
+  ///
+  /// Sets the default [children] constraints sizes.
+  ///
+  /// If you set this value,
+  /// the length of [constraints] must match the one of [children].
+  /// If you don't want to set constraints to one child, just set it to [null] or [BoxConstraints()].
+  ///
+  /// If this value is [null], [children] will be resized without any constraints.
+  final List<BoxConstraints?>? constraints;
+
   /// When set to true, creates horizontal separators.
   @Deprecated('Use [isHorizontalSeparator] instead')
   final bool isColumnChildren;
@@ -53,8 +66,8 @@ class ResizableWidget extends StatefulWidget {
     Key? key,
     required this.children,
     this.percentages,
-    @Deprecated('Use [isHorizontalSeparator] instead')
-        this.isColumnChildren = false,
+    this.constraints,
+    @Deprecated('Use [isHorizontalSeparator] instead') this.isColumnChildren = false,
     this.isHorizontalSeparator = false,
     this.isDisabledSmartHide = false,
     this.separatorSize = 4,
@@ -63,8 +76,8 @@ class ResizableWidget extends StatefulWidget {
   }) : super(key: key) {
     assert(children.isNotEmpty);
     assert(percentages == null || percentages!.length == children.length);
-    assert(percentages == null ||
-        percentages!.reduce((value, element) => value + element) == 1);
+    assert(constraints == null || constraints!.length == children.length);
+    assert(percentages == null || percentages!.reduce((value, element) => value + element) == 1);
   }
 
   @override
@@ -85,17 +98,16 @@ class _ResizableWidgetState extends State<ResizableWidget> {
 
   @override
   Widget build(BuildContext context) => LayoutBuilder(
-        builder: (context, constraints) {
-          _controller.setSizeIfNeeded(constraints);
-          return StreamBuilder(
-            stream: _controller.eventStream.stream,
-            builder: (context, snapshot) => _info.isHorizontalSeparator
-                ? Column(
-                    children: _controller.children.map(_buildChild).toList())
-                : Row(children: _controller.children.map(_buildChild).toList()),
-          );
-        },
+    builder: (context, constraints) {
+      _controller.setSizeIfNeeded(constraints);
+      return StreamBuilder(
+        stream: _controller.eventStream.stream,
+        builder: (context, snapshot) => _info.isHorizontalSeparator
+            ? Column(children: _controller.children.map(_buildChild).toList())
+            : Row(children: _controller.children.map(_buildChild).toList()),
       );
+    },
+  );
 
   Widget _buildChild(ResizableWidgetChildData child) {
     if (child.widget is Separator) {

--- a/lib/src/resizable_widget_args_info.dart
+++ b/lib/src/resizable_widget_args_info.dart
@@ -21,4 +21,6 @@ class ResizableWidgetArgsInfo {
         separatorSize = widget.separatorSize,
         separatorColor = widget.separatorColor,
         onResized = widget.onResized;
+
+  bool get isVerticalSeparator => !isHorizontalSeparator;
 }

--- a/lib/src/resizable_widget_args_info.dart
+++ b/lib/src/resizable_widget_args_info.dart
@@ -4,6 +4,7 @@ import 'resizable_widget.dart';
 class ResizableWidgetArgsInfo {
   final List<Widget> children;
   final List<double>? percentages;
+  final List<BoxConstraints?>? constraints;
   final bool isHorizontalSeparator;
   final bool isDisabledSmartHide;
   final double separatorSize;
@@ -13,6 +14,7 @@ class ResizableWidgetArgsInfo {
   ResizableWidgetArgsInfo(ResizableWidget widget)
       : children = widget.children,
         percentages = widget.percentages,
+        constraints = widget.constraints,
         isHorizontalSeparator =
             // TODO: delete the deprecated member on the next minor update.
             // ignore: deprecated_member_use_from_same_package
@@ -21,6 +23,4 @@ class ResizableWidgetArgsInfo {
         separatorSize = widget.separatorSize,
         separatorColor = widget.separatorColor,
         onResized = widget.onResized;
-
-  bool get isVerticalSeparator => !isHorizontalSeparator;
 }

--- a/lib/src/resizable_widget_child_data.dart
+++ b/lib/src/resizable_widget_child_data.dart
@@ -4,7 +4,8 @@ class ResizableWidgetChildData {
   final Widget widget;
   double? size;
   double? percentage;
+  BoxConstraints? constraints;
   double? defaultPercentage;
   double? hidingPercentage;
-  ResizableWidgetChildData(this.widget, this.percentage);
+  ResizableWidgetChildData(this.widget, this.percentage, this.constraints);
 }

--- a/lib/src/resizable_widget_controller.dart
+++ b/lib/src/resizable_widget_controller.dart
@@ -21,15 +21,15 @@ class ResizableWidgetController {
     _model.callOnResized();
   }
 
-  void resize(int separatorIndex, Offset offset) {
-    _model.resize(separatorIndex, offset);
+  void resize(BuildContext context, int separatorIndex, Offset offset) {
+    _model.resize(context, separatorIndex, offset);
 
     eventStream.add(this);
     _model.callOnResized();
   }
 
-  void tryHideOrShow(int separatorIndex) {
-    final result = _model.tryHideOrShow(separatorIndex);
+  void tryHideOrShow(BuildContext context, int separatorIndex) {
+    final result = _model.tryHideOrShow(context, separatorIndex);
 
     if (result) {
       eventStream.add(this);

--- a/lib/src/resizable_widget_model.dart
+++ b/lib/src/resizable_widget_model.dart
@@ -11,20 +11,17 @@ class ResizableWidgetModel {
   final ResizableWidgetArgsInfo _info;
   final children = <ResizableWidgetChildData>[];
   double? maxSize;
-  double? get maxSizeWithoutSeparators => maxSize == null
-      ? null
-      : maxSize! - (children.length ~/ 2) * _info.separatorSize;
+
+  double? get maxSizeWithoutSeparators => maxSize == null ? null : maxSize! - (children.length ~/ 2) * _info.separatorSize;
 
   ResizableWidgetModel(this._info);
 
   void init(SeparatorFactory separatorFactory) {
     final originalChildren = _info.children;
     final size = originalChildren.length;
-    final originalPercentages =
-        _info.percentages ?? List.filled(size, 1 / size);
+    final originalPercentages = _info.percentages ?? List.filled(size, 1 / size);
     for (var i = 0; i < size - 1; i++) {
-      children.add(ResizableWidgetChildData(
-          originalChildren[i], originalPercentages[i]));
+      children.add(ResizableWidgetChildData(originalChildren[i], originalPercentages[i]));
       children.add(ResizableWidgetChildData(
           separatorFactory.call(SeparatorArgsBasicInfo(
             2 * i + 1,
@@ -35,14 +32,11 @@ class ResizableWidgetModel {
           )),
           null));
     }
-    children.add(ResizableWidgetChildData(
-        originalChildren[size - 1], originalPercentages[size - 1]));
+    children.add(ResizableWidgetChildData(originalChildren[size - 1], originalPercentages[size - 1]));
   }
 
   void setSizeIfNeeded(BoxConstraints constraints) {
-    final max = _info.isHorizontalSeparator
-        ? constraints.maxHeight
-        : constraints.maxWidth;
+    final max = _info.isHorizontalSeparator ? constraints.maxHeight : constraints.maxWidth;
     var isMaxSizeChanged = maxSize == null || maxSize! != max;
     if (!isMaxSizeChanged || children.isEmpty) {
       return;
@@ -62,44 +56,21 @@ class ResizableWidgetModel {
     }
   }
 
-  void resize(int separatorIndex, Offset offset) {
-    final leftSize = _resizeImpl(separatorIndex - 1, offset);
-    final rightSize = _resizeImpl(separatorIndex + 1, offset * (-1));
+  void resize(BuildContext context, int separatorIndex, Offset offset) {
+    if (_info.isVerticalSeparator && Directionality.of(context) == TextDirection.rtl) {
+      // Reverse offset if separator is vertical and context direction is Right-to-Left.
+      offset *= -1;
+    }
 
-    if (leftSize < 0) {
-      _resizeImpl(
-          separatorIndex - 1,
-          _info.isHorizontalSeparator
-              ? Offset(0, -leftSize)
-              : Offset(-leftSize, 0));
-      _resizeImpl(
-          separatorIndex + 1,
-          _info.isHorizontalSeparator
-              ? Offset(0, leftSize)
-              : Offset(leftSize, 0));
-    }
-    if (rightSize < 0) {
-      _resizeImpl(
-          separatorIndex - 1,
-          _info.isHorizontalSeparator
-              ? Offset(0, rightSize)
-              : Offset(rightSize, 0));
-      _resizeImpl(
-          separatorIndex + 1,
-          _info.isHorizontalSeparator
-              ? Offset(0, -rightSize)
-              : Offset(-rightSize, 0));
-    }
+    _resizeImpl(separatorIndex - 1, offset);
+    _resizeImpl(separatorIndex + 1, offset * (-1));
   }
 
   void callOnResized() {
-    _info.onResized?.call(children
-        .where((x) => x.widget is! Separator)
-        .map((x) => WidgetSizeInfo(x.size!, x.percentage!))
-        .toList());
+    _info.onResized?.call(children.where((x) => x.widget is! Separator).map((x) => WidgetSizeInfo(x.size!, x.percentage!)).toList());
   }
 
-  bool tryHideOrShow(int separatorIndex) {
+  bool tryHideOrShow(BuildContext context, int separatorIndex) {
     if (_info.isDisabledSmartHide) {
       return false;
     }
@@ -116,21 +87,15 @@ class ResizableWidgetModel {
     final coefficient = isLeft ? 1 : -1;
     if (_isNearlyZero(size)) {
       // show
-      final offsetScala =
-          maxSize! * (target.hidingPercentage ?? target.defaultPercentage!) -
-              size;
-      final offset = _info.isHorizontalSeparator
-          ? Offset(0, offsetScala * coefficient)
-          : Offset(offsetScala * coefficient, 0);
-      resize(separatorIndex, offset);
+      final offsetScala = maxSize! * (target.hidingPercentage ?? target.defaultPercentage!) - size;
+      final offset = _info.isHorizontalSeparator ? Offset(0, offsetScala * coefficient) : Offset(offsetScala * coefficient, 0);
+      resize(context, separatorIndex, offset);
     } else {
       // hide
       target.hidingPercentage = target.percentage!;
       final offsetScala = maxSize! * target.hidingPercentage!;
-      final offset = _info.isHorizontalSeparator
-          ? Offset(0, -offsetScala * coefficient)
-          : Offset(-offsetScala * coefficient, 0);
-      resize(separatorIndex, offset);
+      final offset = _info.isHorizontalSeparator ? Offset(0, -offsetScala * coefficient) : Offset(-offsetScala * coefficient, 0);
+      resize(context, separatorIndex, offset);
     }
 
     return true;
@@ -138,10 +103,8 @@ class ResizableWidgetModel {
 
   double _resizeImpl(int widgetIndex, Offset offset) {
     final size = children[widgetIndex].size ?? 0;
-    children[widgetIndex].size =
-        size + (_info.isHorizontalSeparator ? offset.dy : offset.dx);
-    children[widgetIndex].percentage =
-        children[widgetIndex].size! / maxSizeWithoutSeparators!;
+    children[widgetIndex].size = size + (_info.isHorizontalSeparator ? offset.dy : offset.dx);
+    children[widgetIndex].percentage = children[widgetIndex].size! / maxSizeWithoutSeparators!;
     return children[widgetIndex].size!;
   }
 

--- a/lib/src/separator.dart
+++ b/lib/src/separator.dart
@@ -39,7 +39,7 @@ class _SeparatorState extends State<Separator> {
             height: _info.isHorizontalSeparator ? _info.size : double.infinity,
           ),
         ),
-        onPanUpdate: (details) => _controller.onPanUpdate(details, context),
-        onDoubleTap: () => _controller.onDoubleTap(),
+        onPanUpdate: (details) => _controller.onPanUpdate(context, details),
+        onDoubleTap: () => _controller.onDoubleTap(context),
       );
 }

--- a/lib/src/separator_controller.dart
+++ b/lib/src/separator_controller.dart
@@ -7,11 +7,11 @@ class SeparatorController {
 
   const SeparatorController(this._index, this._parentController);
 
-  void onPanUpdate(DragUpdateDetails details, BuildContext context) {
-    _parentController.resize(_index, details.delta);
+  void onPanUpdate(BuildContext context, DragUpdateDetails details) {
+    _parentController.resize(context, _index, details.delta);
   }
 
-  void onDoubleTap() {
-    _parentController.tryHideOrShow(_index);
+  void onDoubleTap(BuildContext context) {
+    _parentController.tryHideOrShow(context, _index);
   }
 }

--- a/lib/src/widget_size_info.dart
+++ b/lib/src/widget_size_info.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+
 /// Information about an internal widget size of [ResizableWidget].
 class WidgetSizeInfo {
   /// The actual pixel size.
@@ -11,6 +13,11 @@ class WidgetSizeInfo {
   /// because the ratio of the internal widgets will be maintained.
   final double percentage;
 
+  /// Constraints among the [ResizableWidget] children.
+  ///
+  /// Used to force the widget to doesn't break constraints sizes.
+  final BoxConstraints? constraints;
+
   /// Creates [WidgetSizeInfo].
-  const WidgetSizeInfo(this.size, this.percentage);
+  const WidgetSizeInfo(this.size, this.percentage, this.constraints);
 }


### PR DESCRIPTION
This PR introduces support for child constraints in ResizableWidget and updates the example to demonstrate the new feature.


### Changes:

✅ **Library Enhancements:**
- Added min/max constraints for child widgets.
- Ensured resizing respects these constraints.
- Prevented widgets from exceeding max size or shrinking below min size.
- Improved stability when resizing separators or the whole widget.

✅ **Example Updates:**
- Implemented child constraints in the example.
- Added widgets with different min/max constraints.
- Demonstrated resizing behavior within constraints.
- Improved UI to visualize size limits dynamically.

**Why is this needed?**
- Ensures a better user experience by preventing unintended shrinking/stretching.
- Makes the widget more flexible for various use cases.

Related Issues:
(If applicable, reference related issues or discussions.)

Let me know if you'd like any refinements! 🚀







